### PR TITLE
Add simple buy

### DIFF
--- a/main.py
+++ b/main.py
@@ -155,7 +155,7 @@ def parse(args):
     parser.add_argument('-i', '--item', default=None, nargs='?', dest='item', help='Specifies the item you wish to buy')
     parser.add_argument('-c', '--count', default=1, nargs='?', dest='count', help='Specifies the amount of items you wish to buy')
     parser.add_argument('-b', '--balance', action='store_true', help='Output only stregdollar balance')
-    parser.add_argument('product', type=int, nargs='?', help="Specifies the product to buy")
+    parser.add_argument('product', type=str, nargs='?', help="Specifies the product to buy")
 
     return parser.parse_args(args)
 

--- a/main.py
+++ b/main.py
@@ -155,6 +155,7 @@ def parse(args):
     parser.add_argument('-i', '--item', default=None, nargs='?', dest='item', help='Specifies the item you wish to buy')
     parser.add_argument('-c', '--count', default=1, nargs='?', dest='count', help='Specifies the amount of items you wish to buy')
     parser.add_argument('-b', '--balance', action='store_true', help='Output only stregdollar balance')
+    parser.add_argument('product', type=int, nargs='?', help="Specifies the product to buy")
 
     return parser.parse_args(args)
 
@@ -242,9 +243,11 @@ def get_saved_user() -> str:
         with open(os.path.expanduser(path)) as f:
             line = f.readline()
             matches = re.search('user=(.+)', line)
-            if not not matches.group(1):
+            if not matches:
+                print(f"Hov, din config: '{line}' ser ikke rigtig ud. Skriv 'user=$dit_username")
+                return None
+            elif matches.group(1):
                 return matches.group(1)
-
     return None
 
 def main():
@@ -252,6 +255,17 @@ def main():
 
     if args.user is None:
         args.user = get_saved_user()
+
+    if args.user and args.product:
+        if test_user(args.user):
+            sale(args.user, args.item if args.item else str(args.product), args.count)
+        else:
+            print('''Det var sært, %user%.
+        Det lader ikke til, at du er registreret som aktivt medlem af F-klubben i TREOENs database.
+        Måske tastede du forkert?
+        Hvis du ikke er medlem, kan du blive det ved at følge guiden på fklub.dk.'''.replace('%user%', user))
+
+        return
 
     if not is_int(args.count):
         print('Mængder skal være heltal')


### PR DESCRIPTION
Such that you don't need `sts -i 42` and can just say `sts 42` but only when user is given through config.

Also adds a nullcheck for config parsing which was borked before.