### PR TITLE
Added readonly check to the update command

### DIFF
--- a/main.py
+++ b/main.py
@@ -376,7 +376,7 @@ def calculate_sha256_binary(binary) -> str:
 
 def update_script():
     if not os.access(__file__, os.W_OK):
-        print('Stregsystemet-CLI er i read-only mode og kan derfor ikke opdateres. Er du på NIX OS?')
+        print('Stregsystemet-CLI er i læs-kun modus og kan derfor ikke opdateres. Er du på NIX operativsystem?')
         return
 
     r = requests.get('https://raw.githubusercontent.com/f-klubben/stregsystemet-cli/master/main.py')


### PR DESCRIPTION
For users on NIX os the update command does not make a lot of sense, as when they install sts using the nix package manager, the file is saved as readonly. Therefore a check for readonly mode has been added, preventing update, if write permission is not set. This closes #45 