### PR TITLE
Fix windows terminal colours

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,13 +19,16 @@ else:
     url = 'https://stregsystem.fklub.dk'
     room = '10'
 
-is_windows_terminal = sys.platform == "win32" and os.environ.get("WT_SESSION")
+is_windows = sys.platform == "win32"
 exit_words = [':q', 'exit', 'quit', 'q']
 referer_header = {'Referer': url}
 balance = float()
 config = configparser.ConfigParser()
 
 user_id = ''
+
+if is_windows:
+    os.system('color')
 
 SHORTHANDS = {
     'porter': 42,
@@ -99,7 +102,7 @@ def print_wares(wares):
     print('{:<8} {:<50} {:<10}'.format('Id', 'Item', 'Price'))
     print('-' * 68)
     for ware in wares:
-        if re.match("<\w\d>", ware[1]) and (sys.platform == 'linux' or is_windows_terminal):
+        if re.match("<\w\d>", ware[1]):
             r = re.sub("<br>", ' - ', ware[1])
             r = re.sub("<\w\d> | </\w\d>|<\w\w>|</\w\d>", '', r)
             print('\u001B[31m{:<8} {:<50} {:<10}\u001B[0m'.format(ware[0], r, ware[2]))


### PR DESCRIPTION
This PR fixes an issue where terminal colours do not show properly in powershell and cmd on windows. It does not affect windows terminal as this treats colours like a unix terminal. 